### PR TITLE
change bootmortis project to MasterKia fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
           cd code
           echo "downloading from https://raw.githubusercontent.com/filteryab/filteryab/main/iran/blocked-in-iran"
           curl -L -o data/hiddify-ir-filteryab https://raw.githubusercontent.com/filteryab/ir-blocked-domain/main/data/ir-blocked-domain
-          echo "downloading from https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/domains.txt"
-          curl -L -o data/hiddify-ir-iran-hosted-domains https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/domains.txt
+          echo "downloading from https://github.com/MasterKia/iran-hosted-domains/releases/latest/download/domains.txt"
+          curl -L -o data/hiddify-ir-iran-hosted-domains https://github.com/MasterKia/iran-hosted-domains/releases/latest/download/domains.txt
           echo "removing .ir domains"
           grep -vE '\.ir$' data/hiddify-ir-iran-hosted-domains > 'data/hiddify-ir-iran-hosted-domains-!ir'
           echo "Downloading from https://raw.githubusercontent.com/freedomofdevelopers/fod/master/domains"


### PR DESCRIPTION
کامل ترین لیست سایت های تبلیغات ایرانی، پروژه https://github.com/MasterKia/PersianBlocker است که به صورت مستمر نیز آپدیت می‌شود. پروژه https://github.com/bootmortis/iran-hosted-domains هم از همین لیست استفاده می‌کرد. مدتی پیش bootmortis تصمیم گرفت منبع سایت تبلیغات خود را عوض کند، نه به این دلیل که لیست کامل‌تری وجود دارد، بلکه به دلیل اینکه پروژه PersianBlocker از لایسنس GPL استفاده میکرد و پروژه bootmortis/iran-hosted-domains از لایسنس MIT استفاده میکرد و نمی‌توانست بدون تغییر لایسنس از آن منبع استفاده کند. شرح کامل ماجرا: bootmortis/iran-hosted-domains#27
بعد از آن، MasterKia پروژه iran-hosted-domains را با لایسنس GPL فورک کرد و لیست خود را که کامل تر بود را دوباره برگرداند. پیشنهاد می‌کنم در پروژه شما، پروژه https://github.com/MasterKia/iran-hosted-domains جایگزین https://github.com/bootmortis/iran-hosted-domains/ شود. البته دیدم که لایسنس این پروژه که شما از https://github.com/v2fly/domain-list-community/ فورک کردید هنوز MIT هست و تغییرش ندادید. لایسنس MIT اصلا مالکیت معنوی را حمایت نمیکند. پس اگر شما هم لایسنس این پروژه را به خانواده GPL یا لایسنسی که مالکیت معنوی را حفظ کند تغییر دهید، مشکل لایسنس نیز نخواهید داشت. اتفاقا به خاطر دارم در زمان متن باز کردن پنل، دغدغه مالکیت معنوی را داشتید و این تغیر لایسنس در راستای دغدغه شما هم هست.